### PR TITLE
feat: only refresh token when time is running out

### DIFF
--- a/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -183,7 +183,7 @@ function Invoke-MetasysMethod {
 
         if ([MetasysEnvVars]::getExpires()) {
             $expiration = [Datetime]::Parse([MetasysEnvVars]::getExpires())
-            if ([Datetime]::UtcNow -gt $expiration) {
+            if ([DateTime]::UtcNow -gt $expiration) {
                 # Token is expired, require login
                 $ForceLogin = $true
             }
@@ -194,11 +194,11 @@ function Invoke-MetasysMethod {
                     -token ([MetasysEnvVars]::getToken()) -skipCertificateCheck:$SkipCertificateCheck
 
                 try {
-                    Write-Verbose -Message "Attempting to refresh access token"
+                    Write-Information -Message "Attempting to refresh access token"
                     $refreshResponse = Invoke-RestMethod @refreshRequest
                     [MetasysEnvVars]::setExpires($refreshResponse.expires)
                     [MetasysEnvVars]::setToken((ConvertTo-SecureString $refreshResponse.accessToken -AsPlainText))
-                    Write-Verbose -Message "Refresh token successful"
+                    Write-Information -Message "Refresh token successful"
                 }
                 catch {
                     Write-Debug "Error attempting to refresh token"
@@ -240,7 +240,7 @@ function Invoke-MetasysMethod {
             }
 
             if (!$Password) {
-                Write-Verbose -Message "Attempting to get password for $SiteHost $UserName"
+                Write-Information -Message "Attempting to get password for $SiteHost $UserName"
 
                 $password = invokeWithWarningsOff -script { Get-SavedMetasysPassword -SiteHost $SiteHost -UserName $UserName }
 
@@ -269,7 +269,7 @@ function Invoke-MetasysMethod {
 
             invokeWithWarningsOff -script { Set-SavedMetasysPassword -SiteHost $SiteHost -UserName $UserName -Password $Password }
 
-            Write-Verbose -Message "Login successful"
+            Write-Information -Message "Login successful"
         }
 
         if (!$Path) {
@@ -284,7 +284,7 @@ function Invoke-MetasysMethod {
         $response = $null
         $responseObject = $null
 
-        Write-Verbose -Message "Attempting request"
+        Write-Information -Message "Attempting request"
         $responseObject = Invoke-WebRequest @request -SkipHttpErrorCheck
         if ($responseObject.StatusCode -ge 400) {
             Write-Error "The status code indicates an error"

--- a/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -150,6 +150,7 @@ function Invoke-MetasysMethod {
     # PROCESS block is needed if you accept input from pipeline like Body in this function
     PROCESS {
 
+        Set-Variable -Name fiveMinutes -Value ([TimeSpan]::FromMinutes(5)) -Option Constant
 
         setBackgroundColorsToMatchConsole
 
@@ -186,7 +187,7 @@ function Invoke-MetasysMethod {
                 # Token is expired, require login
                 $ForceLogin = $true
             }
-            else {
+            elseif ([DateTime]::UtcNow -gt $expiration - $fiveMinutes) {
 
                 # attempt to renew the token to keep it fresh
                 $refreshRequest = buildRequest -method "Get" -uri (buildUri -path "/refreshToken" -version $Version) `


### PR DESCRIPTION
There's no need to try refreshing token on every single invocation.
Now we check to see if there's less than 5 minutes left before session
expires. If so, then we attempt a refresh.

Fix #14