### PR TITLE
fix: correct env vars for version

### DIFF
--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -8,11 +8,11 @@ class MetasysEnvVars {
         $env:METASYS_HOST = $siteHost
     }
 
-    static [int] getVersion() {
+    static [string] getVersion() {
         return $env:METASYS_VERSION
     }
 
-    static [void] setVersion([int]$version) {
+    static [void] setVersion([string]$version) {
         $env:METASYS_VERSION = $version
     }
 


### PR DESCRIPTION
In df86dd3 we made `version` be a string but MetasysEnvVars still had a getter and a setter that expected it to be an int.