### PR TITLE
feat: add first config file support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,28 @@
 {
     "cSpell.words": [
+        "Adsrepos",
+        "Apdu",
+        "bacdevice",
+        "bacnet",
+        "boce",
+        "Clas",
+        "cmdlet",
+        "Cmdparm",
+        "fips",
         "Hashtable",
+        "hvac",
         "Keychain",
+        "maxage",
         "Metasys",
-        "cmdlet"
+        "metasysrestclient",
+        "myhost",
+        "nosniff",
+        "Nxes",
+        "Parms",
+        "Sched",
+        "struct",
+        "ulong",
+        "welchoas"
     ],
     "[markdown]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/README.md
+++ b/README.md
@@ -1464,6 +1464,95 @@ X-Content-Type-Options: nosniff
 Set-Cookie: Secure; HttpOnly
 ```
 
+## Configuration
+
+The Metasys Rest Client supports a limited amount of configuration. To configure
+the app create a `.metasysrestclient` file in your home directory.
+
+The configuration allows you to specify the default values to use when invoking
+`Connect-MetasysAccount` for a specific host.
+
+The following properties are supported:
+
+- `hosts` - An array of entries that describe a host you want to connect to.
+  Each entry must contain an `alias` and a `hostname`. Optionally, you can
+  specify other properties for a host as well. You can have multiple entries for
+  the same `hostname` as long as they have different aliases.
+
+A host entry has the following properties:
+
+- `hostname` **required** `string` - The resolvable hostname or ip address of a
+  host.
+- `alias` **required** `string` - An alias to assign to that host. This alias
+  can then be used as the `MetasysHost` parameter in an invocation of
+  `Connect-MetasysAccount`
+- `user` _optional_ `string` - The user account to use to log into `hostname`.
+  If specified, this will be used as the `UserName` parameter in an invocation
+  of `Connect-MetasysAccount`.
+- `version` _optional_ `string` - The version of the API to use for this host.
+- `skip-certificate-check` _optional_ `switch` - Set this to any value to
+  specify that you want certificate checking skipped. Typically you would use
+  `true` but any value (including `false` and `null`) means the same thing. You
+  must delete this key to restore certificate checking. (The same warnings apply
+  as to those given for `-SkipCertificateCheck` above.)
+
+### Example Configuration
+
+Assume you had the following content in `$HOME/.metasysrestclient`
+
+```jsonc
+{
+  "hosts": [
+    {
+      "hostname": "myhost.domain",
+      "alias": "myhost"
+    },
+    {
+      "hostname": "host2.domain",
+      "alias": "host2"
+    },
+    {
+      "hostname": "myhost.domain",
+      "alias": "myhost2",
+      "user": "john_smith",
+      "version": "4",
+      "skip-certificate-check": true
+    }
+  ]
+}
+```
+
+Then the following two commands are equivalent as they both would attempt to
+connect to `myhost.domain`
+
+```bash
+Connect-MetasysAccount -MetasysHost myhost
+Connect-MetasysAccount -MetasysHost myhost.domain
+```
+
+Likewise the following two commands are equivalent. Both attempt to login to
+`myhost.domain` with a `UserName` of `john_smith`, using version `4` and
+skipping any certificate checks.
+
+```bash
+Connect-MetasysAccount -MetasysHost myhost.domain -UserName john_smith -Version 4 -SkipCertificateCheck
+Connect-MetasysAccount -MetasysHost myhost2
+```
+
+> **Note** \
+> If you supply a value for `-UserName` it will override any `username` value in
+> `.metasysrestclient`. Likewise, if you supply a value for `-Version` it will override
+> any `version` value in `.metasysrestclient`.
+
+For example
+
+```bash
+Connect-MetasysAccount myhost2 -Version 3 -UserName bob
+```
+
+Will use a version `3` and user `bob` instead of the values in
+`.metasysrestclient`.
+
 ## Troubleshooting
 
 ### Invalid Certificates
@@ -1472,9 +1561,12 @@ This command will fail to execute if the server you are executing against
 doesn't have a valid certificate. A parameter is provided,
 `SkipCertificateCheck`, which causes all validation checks to be skipped. This
 includes all validations such as expiration, revocation, trusted root authority,
-etc. **WARNING** Using this parameter is not secure and is not recommended. This
-switch is intended to be used against known hosts using a self-signed
-certificate for testing purposes. _Use at your own risk_.
+etc.
+
+> **WARNING** \
+> Using this parameter is not secure and is not recommended. This switch is intended
+> to be used against known hosts using a self-signed certificate for testing purposes.
+> _Use at your own risk_.
 
 ## Known Limitations
 

--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -175,6 +175,10 @@ function Invoke-MetasysMethod {
             $Path = Read-Host -Prompt "Path"
         }
 
+        # Read SkipCertificateCheck from environment
+        $SkipCertificateCheck = [MetasysEnvVars]::getSkipCertificateCheck()
+
+
         if (!$SkipCertificateCheck.IsPresent) {
             $SkipCertificateCheck = [MetasysEnvVars]::getDefaultSkipCheck()
         }

--- a/src/MetasysRestClient/MetasysRestClient.psd1
+++ b/src/MetasysRestClient/MetasysRestClient.psd1
@@ -8,7 +8,7 @@
     # Script module or binary module file associated with this manifest.
     RootModule           = 'Invoke-MetasysMethod.psm1'
 
-    NestedModules        = @("metasys-env-vars.ps1", "PasswordManagement.ps1", "build-uri.ps1", "build-request.ps1", "Connect-MetasysAccount.ps1")
+    NestedModules        = @("metasys-env-vars.ps1", "PasswordManagement.ps1", "build-uri.ps1", "build-request.ps1", "Connect-MetasysAccount.ps1", "Read-ConfigFile.ps1")
 
     # Version number of this module.
     ModuleVersion        = '2.1.3'

--- a/src/MetasysRestClient/Read-ConfigFile.ps1
+++ b/src/MetasysRestClient/Read-ConfigFile.ps1
@@ -1,0 +1,35 @@
+
+function Read-ConfigFile {
+    <#
+    .Synopsis
+    Read the file $HOME/.metasysrestclient and return a host entry that corresponds to the given alias.
+
+    .DESCRIPTION
+
+
+    .Example
+    #>
+    param(
+        [string]$Alias
+    )
+    $config = $null
+    $config = Get-Content "$HOME/.metasysrestclient" -Raw -ErrorAction SilentlyContinue
+    if ($config) {
+        $configs = $null
+        $configs = ConvertFrom-Json $config  -ErrorAction SilentlyContinue
+        if ($configs) {
+            $hosts = $configs.hosts
+            if ($hosts) {
+                # Return the last match option
+                $hostEntry = $hosts.Where{ $_.alias -eq $Alias} | Select-Object -First 1
+                if ($hostEntry.psobject.properties['hostname']) {
+                    $hostEntry
+                }
+            }
+        } else {
+            $path = $HOME + "/.metasysapirc"
+            Write-Error "Cannot parse '$path' file. Expected valid JSON."
+            Exit
+        }
+    }
+}

--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -93,6 +93,14 @@ class MetasysEnvVars {
         return $env:METASYS_SKIP_CHECK_NOT_SECURE
     }
 
+    static [Boolean] getSkipCertificateCheck() {
+        return $env:METASYS_SKIP_CERTIFICATE_CHECK
+    }
+
+    static [void] setSkipCertificateCheck([Boolean]$SkipCertificateCheck) {
+        $env:METASYS_SKIP_CERTIFICATE_CHECK = $SkipCertificateCheck
+    }
+
     static [string] getUserName() {
         return $env:METASYS_USER_NAME
     }


### PR DESCRIPTION
See README for more details.

Connect-MetasysAccount will now consult a file named
`$HOME/.metasysrestclient`. This is expected to be JSON file with a 
property named `hosts`. This is an array of "host entries". Each host 
entry must needs at a minimum an "alias" and a "hostname" property. This
allows you to specify an alias for -MetasysHost when calling 
Connect-MetasysAccount. 

Other properties that can be in a host entry are

- username 
- version
- skip-certificate-check