### PR TITLE
feat: add tab completions for aliases

### DIFF
--- a/src/MetasysRestClient/Connect-MetasysAccount.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.ps1
@@ -13,6 +13,25 @@ function Connect-MetasysAccount {
     .DESCRIPTION
     The `Connect-MetasysAccount` function connects to a Metasys site with an authenticated account for use with functions from the MetasysRestClient PowerShell module.
 
+    The alias for this command is `cma`. Some of the examples in this help use `cma` instead of `Connect-MetasysAccount`.
+
+    DYNAMIC PARAMETERS
+
+    Connect-MetasysAccount offers a very useful dynamic parameter. The Alias parameter features tab completion so that you can easily select the host you want to connect to. The list of choices is dyanmically read from your configuration file. (See NOTES)
+
+    -Alias <System.String>
+
+    An alias from your configuration file. See NOTES for more information on configuring an alias. If you specify an Alias and a MetasysHost the Alias is given precedence.
+
+    NOTE: This is the only positional parameter so you can invoke this command as simply as this:
+
+    > cma myhost
+
+    assuming myhost is a configured alias.
+
+    .PARAMETER Alias
+    An alias from your configuration file. See NOTES for more information on configuration files.
+
     .Example
     Connect-MetasysAccount
 
@@ -24,19 +43,52 @@ function Connect-MetasysAccount {
 
     After prompting for a password (stored as a secure string), connects the host named `oas` with the specified user name and password.
 
+    .Example
+    cma host1
+
+    Assuming you have this alias in your configuration file (see NOTES), this will prompt you for your password and connect you with the configured username and version.
+
     .NOTES
-    The Metasys REST API mandates that you specify the version of the API you wish to call. This command assumes that you wish to use the latest version of the API (v5 at time of writing). If you wish to use an older version of the API use the -Version parameter. To avoid having to specify this every time you connect you can modify your start up profile to set the environment variable $env:METASYS_DEFAULT_API_VERSION to which ever version you wish. (For example you could set it to 4).
+    The Metasys REST API mandates that you specify the version of the API you wish to call. This command assumes that you wish to use the latest version of the API (v5 at time of writing). If you wish to use an older version of the API use the -Version parameter. To avoid having to specify this every time you connect you have two choices. You can use a configuration file as described below to specify a different version for each host you connect to. Or you can modify your start up profile to set the environment variable $env:METASYS_DEFAULT_API_VERSION to which ever version you wish. (For example you could set it to 4).
 
     Whichever version of the API was used to connect to Metasys will be used for every other call in your session (unless you override that with the -Version parameter or by specifying a full URL).
+
+    Connecting to a site can be greatly simplified with the use of a configuration file named .metasysrestclient in your home directory. The file should be JSON and should look something like this
+
+    {
+        "hosts": [
+            {
+                "alias": "host1",
+                "hostname": "host1.company.com"
+            },
+            {
+                "alias": "myhost",
+                "hostname": "myhost.company.com",
+                "username": "john",
+                "version": "4",
+                "skip-certificate-check": true
+            }
+        ]
+    }
+
+    In a valid configuration file each host entry must have an alias and a hostname. The other properties are optional but typically very useful.
+
+    With this configuration file in place I can connect to myhost.company.com, with user "john", and using version 4 with this command:
+
+    cma myhost
+
+    TAB COMPLETION
+
+    With a configuration file in place you can use tab completion to pick the host you want. If you don't recall all of your aliases, just type `cma <TAB KEY>` and they will all be listed.
+
     #>
-    [CmdLetBinding(PositionalBinding = $true)]
+    [CmdLetBinding(PositionalBinding = $false)]
     param(
 
         # A hostname or ip address. This is the device `Connect-MetasysAccount` will athenticated with.
         #
         # Aliases: -h, -host, -SiteHost
         [Alias("h", "host", "SiteHost")]
-        [Parameter(Position=0)]
         [String]$MetasysHost,
 
         # The username of an account on the host
@@ -65,82 +117,120 @@ function Connect-MetasysAccount {
         # self-signed certificate for testing purposes. Use at your own risk.
         [Switch]$SkipCertificateCheck
     )
+    DynamicParam {
 
-    Clear-MetasysEnvVariables | Out-Null
+        # Set the dynamic parameters' name
+        $ParameterName = 'Alias'
 
-    if (!$MetasysHost) {
-        Write-Information "No MetasysHost specified. Prompting for value."
-        $MetasysHost = Read-Host -Prompt "Metasys Host"
+        # Create the dictionary
+        $RuntimeParameterDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+
+        # Create the collection of attributes
+        $AttributeCollection = New-Object System.Collections.ObjectModel.Collection[System.Attribute]
+
+        # Create and set the parameters' attributes
+        $ParameterAttribute = New-Object System.Management.Automation.ParameterAttribute
+        $ParameterAttribute.Mandatory = $false
+        $ParameterAttribute.Position = 0
+
+        # Add the attributes to the attributes collection
+        $AttributeCollection.Add($ParameterAttribute)
+
+        # Generate and set the ValidateSet
+        $arrSet = ReadAliases
+        $ValidateSetAttribute = New-Object System.Management.Automation.ValidateSetAttribute($arrSet)
+
+        # Add the ValidateSet to the attributes collection
+        $AttributeCollection.Add($ValidateSetAttribute)
+
+        # Create and return the dynamic parameter
+        $RuntimeParameter = New-Object System.Management.Automation.RuntimeDefinedParameter($ParameterName, [string], $AttributeCollection)
+        $RuntimeParameterDictionary.Add($ParameterName, $RuntimeParameter)
+        return $RuntimeParameterDictionary
     }
 
-    # Use the config file (if present) to lookup the actual host name
-    # and user name (if supplied)
-    $HostEntry = Read-ConfigFile -Alias $MetasysHost
-    if ($HostEntry) {
-        $HostEntryProperties = $HostEntry.PSObject.Properties
-        $MetasysHost = $HostEntry.hostname
-        Write-Information "Alias '$($HostEntry.alias)' found in '.metasysrestclient'. Using '$MetasysHost' as new value for -MetaysHost"
-        if (!$UserName -and $HostEntryProperties['username']) {
-            $UserName = $HostEntry.username
-            Write-Information "Alias '$($HostEntry.alias)' has an associated username. Using '$UserName' as value for -UserName"
+    begin {
+        # Bind the parameter to a friendly variable
+        $Alias = $PSBoundParameters[$ParameterName]
+    }
+
+    process {
+        Clear-MetasysEnvVariables | Out-Null
+
+        # Use the config file (if present) to lookup the actual host name
+        # and user name (if supplied)
+        $HostEntry = Read-ConfigFile -Alias $Alias
+        if ($HostEntry) {
+            $HostEntryProperties = $HostEntry.PSObject.Properties
+            $MetasysHost = $HostEntry.hostname
+            Write-Information "Alias '$($HostEntry.alias)' found in '.metasysrestclient'. Using '$MetasysHost' as new value for -MetaysHost"
+            if (!$UserName -and $HostEntryProperties['username']) {
+                $UserName = $HostEntry.username
+                Write-Information "Alias '$($HostEntry.alias)' has an associated username. Using '$UserName' as value for -UserName"
+            }
+            if (!$Version -and $HostEntryProperties['version']) {
+                $Version = $HostEntry.version
+                Write-Information "Alias '$($HostEntry.alias)' has an associated version. Using '$Version' as value for -Version"
+            }
+            if ($HostEntryProperties['skip-certificate-check']) {
+                $SkipCertificateCheck = $true
+                Write-Information "Alias s'$($HostEntry.alias)' is configured to skip certificate checking."
+            }
         }
-        if (!$Version -and $HostEntryProperties['version']) {
-            $Version = $HostEntry.version
-            Write-Information "Alias '$($HostEntry.alias)' has an associated version. Using '$Version' as value for -Version"
+
+        if (!$MetasysHost) {
+            Write-Information "No MetasysHost specified. Prompting for value."
+            $MetasysHost = Read-Host -Prompt "Metasys Host"
         }
-        if ($HostEntryProperties['skip-certificate-check']) {
-            $SkipCertificateCheck = $true
-            Write-Information "Alias s'$($HostEntry.alias)' is configured to skip certificate checking."
+
+        if (!$UserName) {
+            Write-Information "No UserName specified. Searching secret management."
+            $users = Get-SavedMetasysUsers -SiteHost $MetasysHost
+
+            if ($users -and $users.Count -eq 1) {
+                Write-Information "A single matching user account found for $MetasysHost"
+                $UserName = $users | Select-Object -ExpandProperty UserName
+            }
+            else {
+                Write-Information "Multiple matching user accounts found for $MetasysHost. Prompting for value for UserName."
+                $UserName = Read-Host -Prompt "UserName"
+            }
         }
-    }
 
-    if (!$UserName) {
-        Write-Information "No UserName specified. Searching secret management."
-        $users = Get-SavedMetasysUsers -SiteHost $MetasysHost
-
-        if ($users -and $users.Count -eq 1) {
-            Write-Information "A single matching user account found for $MetasysHost"
-            $UserName = $users | Select-Object -ExpandProperty UserName
+        if (!$Password) {
+            Write-Information "No Password specified. Search secret management for user $UserName on $MetasysHost and if none found prompting for value."
+            $Password = (Get-SavedMetasysPassword -SiteHost $MetasysHost -UserName $UserName) ?? (Read-Host -Prompt "Password" -AsSecureString)
         }
-        else {
-            Write-Information "Multiple matching user accounts found for $MetasysHost. Prompting for value for UserName."
-            $UserName = Read-Host -Prompt "UserName"
+
+        if ($Version -eq "") {
+            $Version = $env:METASYS_DEFAULT_API_VERSION ?? $LatestVersion
+            Write-Information "No version specified. Defaulting to v$Version"
         }
-    }
 
-    if (!$Password) {
-        Write-Information "No Password specified. Search secret management for user $UserName on $MetasysHost and if none found prompting for value."
-        $Password = (Get-SavedMetasysPassword -SiteHost $MetasysHost -UserName $UserName) ?? (Read-Host -Prompt "Password" -AsSecureString)
-    }
+        $body = @{
+            username = $UserName;
+            password = ConvertFrom-SecureString -AsPlainText $Password
+        } | ConvertTo-Json
 
-    if ($Version -eq "") {
-        $Version = $env:METASYS_DEFAULT_API_VERSION ?? $LatestVersion
-        Write-Information "No version specified. Defaulting to v$Version"
-    }
+        $uri = "https://$MetasysHost/api/v$Version/login"
+        try {
+            Write-Information "Invoke-RestMethod -Uri $uri -Method Post -ContentType 'application/json' -Body '{ `"username`": `"$UserName`", `"password`": `"********`" }' -SkipCertificateCheck:`$$SkipCertificateCheck"
+            $response = Invoke-RestMethod -Uri $uri -Method Post -ContentType 'application/json' -Body $body -SkipCertificateCheck:$SkipCertificateCheck
+        }
+        catch {
+            Write-Error $_
+            return
+        }
+        Write-Information "Login was successful. Saving environment variables."
+        [MetasysEnvVars]::setExpires($response.expires)
+        [MetasysEnvVars]::setTokenAsPlainText($response.accessToken)
+        [MetasysEnvVars]::setSiteHost($MetasysHost)
+        [MetasysEnvVars]::setVersion($Version)
+        [MetasysEnvVars]::setSkipCertificateCheck($SkipCertificateCheck)
 
-    $body = @{
-        username = $UserName;
-        password = ConvertFrom-SecureString -AsPlainText $Password
-    } | ConvertTo-Json
-
-    $uri = "https://$MetasysHost/api/v$Version/login"
-    try {
-        Write-Information "Invoke-RestMethod -Uri $uri -Method Post -ContentType 'application/json' -Body '{ `"username`": `"$UserName`", `"password`": `"********`" }' -SkipCertificateCheck:`$$SkipCertificateCheck"
-        $response = Invoke-RestMethod -Uri $uri -Method Post -ContentType 'application/json' -Body $body -SkipCertificateCheck:$SkipCertificateCheck
+        Write-Information "Saving credentials to vault"
+        Set-SavedMetasysPassword -SiteHost $MetasysHost -UserName $UserName -Password $Password
     }
-    catch {
-        Write-Error $_
-        return
-    }
-    Write-Information "Login was successful. Saving environment variables."
-    [MetasysEnvVars]::setExpires($response.expires)
-    [MetasysEnvVars]::setTokenAsPlainText($response.accessToken)
-    [MetasysEnvVars]::setSiteHost($MetasysHost)
-    [MetasysEnvVars]::setVersion($Version)
-    [MetasysEnvVars]::setSkipCertificateCheck($SkipCertificateCheck)
-
-    Write-Information "Saving credentials to vault"
-    Set-SavedMetasysPassword -SiteHost $MetasysHost -UserName $UserName -Password $Password
 }
 
 Set-Alias -Name cma -Value Connect-MetasysAccount

--- a/src/MetasysRestClient/Read-ConfigFile.ps1
+++ b/src/MetasysRestClient/Read-ConfigFile.ps1
@@ -33,3 +33,20 @@ function Read-ConfigFile {
         }
     }
 }
+
+    <#
+    .Synopsis
+    Read the file $HOME/.metasysrestclient and return the list of the aliases found.
+
+    #>
+function ReadAliases {
+    $config = $null
+    $config = Get-Content "$HOME/.metasysrestclient" -Raw -ErrorAction SilentlyContinue
+    if ($config) {
+        $configs = $null
+        $configs = ConvertFrom-Json $config  -ErrorAction SilentlyContinue
+        if ($configs) {
+            $configs.hosts | Select-Object -ExpandProperty alias
+        }
+    }
+}


### PR DESCRIPTION
Changes:

- Add a new dynamic parameter named Alias
- This new parameter is dynamically generated with a ValidateSet that is generated from the aliases in the configuration parameter
- Removed positional parameters from MetasysHost (this is how things always were until this week).
- Made Alias a positional parameter so that one can very easily connect to an alias.
- Since Alias is dynamically generated and provides a ValdiateSet, it offers tab completion.

An example

PS > cma r12

Another example

PS > cma <TAB KEY>`

Results in the following

PS > cma r12
r12       r12mve    r12nomve  r13       test      thesun    usa

And depending on the value of Set-PSReadKeyLineHandler it will cycle through your configured aliases.

To turn this on run this and/or add it to your $PROFILE

Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete