### PR TITLE
docs: add note to state cli overrides any values found in config

### DIFF
--- a/src/MetasysRestClient/Connect-MetasysAccount.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.ps1
@@ -21,7 +21,7 @@ function Connect-MetasysAccount {
 
     -Alias <System.String>
 
-    An alias from your configuration file. See NOTES for more information on configuring an alias. If you specify an Alias and a MetasysHost the Alias is given precedence.
+    An alias from your configuration file. See NOTES for more information on configuring an alias.  If you specify an Alias and a MetasysHost the host specified by Alias is used.
 
     NOTE: This is the only positional parameter so you can invoke this command as simply as this:
 
@@ -80,6 +80,8 @@ function Connect-MetasysAccount {
     TAB COMPLETION
 
     With a configuration file in place you can use tab completion to pick the host you want. If you don't recall all of your aliases, just type `cma <TAB KEY>` and they will all be listed.
+
+    Any parameters given on the command line (-UserName, -Version, -SkipCertificateCheck) will override any values in the configuration file. This allows you to still use an alias to avoid typing a full hostname, but let you override the version (for example).
 
     #>
     [CmdLetBinding(PositionalBinding = $false)]


### PR DESCRIPTION
The cli parameters (-UserName, -Version, -SkipCertificateCheck) on Connect-MetasysAccount override any values that are found for the host entry specified by -Alias.

So if these parameters are not present, the config file values are used. If they are present they override the config values.