### PR TITLE
bug: handle case were no aliases defined

### DIFF
--- a/src/MetasysRestClient/Connect-MetasysAccount.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.ps1
@@ -138,12 +138,14 @@ function Connect-MetasysAccount {
         # Add the attributes to the attributes collection
         $AttributeCollection.Add($ParameterAttribute)
 
-        # Generate and set the ValidateSet
+        # Generate and set the ValidateSet, but only if aliases are found
         $arrSet = ReadAliases
-        $ValidateSetAttribute = New-Object System.Management.Automation.ValidateSetAttribute($arrSet)
+        if ($arrSet) {
+            $ValidateSetAttribute = New-Object System.Management.Automation.ValidateSetAttribute($arrSet)
 
-        # Add the ValidateSet to the attributes collection
-        $AttributeCollection.Add($ValidateSetAttribute)
+            # Add the ValidateSet to the attributes collection
+            $AttributeCollection.Add($ValidateSetAttribute)
+        }
 
         # Create and return the dynamic parameter
         $RuntimeParameter = New-Object System.Management.Automation.RuntimeDefinedParameter($ParameterName, [string], $AttributeCollection)


### PR DESCRIPTION
If there are no aliases, (which is the default if there
is no config file--$HOME/.metasysrestclient) then Connect-MetasysAccount
can't find a constructor for ValidateSet and throws an exception.

Now when building the dynamic param -Alias `cma` will not attempt to
create a ValidateSet if there are no aliases.