### PR TITLE
bug: fix [MetasysEnvVars]::getSkipCertificateCheck

### DIFF
--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -94,7 +94,12 @@ class MetasysEnvVars {
     }
 
     static [Boolean] getSkipCertificateCheck() {
-        return $env:METASYS_SKIP_CERTIFICATE_CHECK
+        # Need to convert string value into Boolean
+        if ($env:METASYS_SKIP_CERTIFICATE_CHECK -eq "True") {
+            return $true
+        } else {
+            return $false
+        }
     }
 
     static [void] setSkipCertificateCheck([Boolean]$SkipCertificateCheck) {


### PR DESCRIPTION
This function was not accounting for the fact that env vars are strings. So if the value $false was written it will have the value "False" when read back (which is considered truthy).

The function now only returns $true if the string value is "True"