### PR TITLE
bug: remove version tests for cma

### DIFF
--- a/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
@@ -286,17 +286,6 @@ Describe "Connect-Metasys" -Tag "Unit" {
             }
         }
 
-        Context "When an invalid version is specified" {
-            It "Should throw an exception for version v<version>" -ForEach @(
-                @{ Version = 1 }
-                @{ Version = 0 }
-                @{ Version = 6 }
-            ) {
-
-                { Connect-MetasysAccount -Version $version } | Should -Throw -ExceptionType  System.Management.Automation.ParameterBindingException
-            }
-        }
-
     }
 
     Describe "Error Processing" {


### PR DESCRIPTION
With the change to [string] type for -Version, the ValidateSet was removed. This is due to the ever change versions we may want to accept in production. The tests for version don't seem important. The user will still get a http exception and likely a 404.