### PR TITLE
test: resolve long delay in test run

### DIFF
--- a/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
@@ -280,16 +280,15 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
     }
 
     Describe 'When -IncludeResponseHeaders with success response' {
+        BeforeAll {
+            Clear-MetasysEnvVariables
+            $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(30)).ToString("o")
+            $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
+            $env:METASYS_VERSION = $LatestVersion
+            $env:METASYS_HOST = "oas12"
+        }
 
         It "Should display response headers and then the response body" {
-            BeforeAll {
-                Clear-MetasysEnvVariables
-                $env:METASYS_EXPIRES = ([DateTimeOffset]::UtcNow + [TimeSpan]::FromMinutes(30)).ToString("o")
-                $env:METASYS_ACCESS_TOKEN = "secure token" | ConvertTo-SecureString -AsPlainText | ConvertFrom-SecureString
-                $env:METASYS_VERSION = $LatestVersion
-                $env:METASYS_HOST = "oas12"
-            }
-
 
             $response = @{
                 StatusCode        = 200;


### PR DESCRIPTION
I don't really understand the root cause. But a BeforeAll was inside of an `It` instead of outside of it. Perhaps this caused it to be called multiple times? It's not clear. But this is definitely the test that slowed everything down. With this commit in place tests run in a few seconeds versus a minute or so.