### PR TITLE
Handle env vars better

### DIFF
--- a/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
@@ -22,7 +22,7 @@ BeforeAll {
 
     . ./MockConsole.ps1
 
-    Set-Variable -Name LatestVersion -Value 4 -Option Constant
+    Set-Variable -Name LatestVersion -Value (Get-MetasysLatestVersion) -Option Constant
 
     function CreateLoginResponse {
         param(

--- a/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.Tests.ps1
@@ -54,6 +54,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
                 Mock Get-SavedMetasysPassword -ModuleName MetasysRestClient
                 Mock Get-SavedMetasysUsers -ModuleName MetasysRestClient
                 Mock Set-SavedMetasysPassword -ModuleName MetasysRestClient
+                Mock Get-MetasysDefaultApiVersion -ModuleName MetasysRestClient
 
                 # qualify with $script to avoid unused-vars warnings from PSScriptAnalyzer
                 $script:response = Connect-MetasysAccount
@@ -133,6 +134,7 @@ Describe "Connect-Metasys" -Tag "Unit" {
                 Mock Invoke-RestMethod -ModuleName MetasysRestClient {
                     $loginResponse
                 }
+                Mock Get-MetasysDefaultApiVersion -ModuleName MetasysRestClient
 
                 $script:metasysHost = "aHost"
                 $script:userName = "aUser"

--- a/src/MetasysRestClient/Connect-MetasysAccount.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.ps1
@@ -207,7 +207,7 @@ function Connect-MetasysAccount {
         }
 
         if ($Version -eq "") {
-            $Version = $env:METASYS_DEFAULT_API_VERSION ?? $LatestVersion
+            $Version = $env:METASYS_DEFAULT_API_VERSION ?? (Get-MetasysLatestVersion)
             Write-Information "No version specified. Defaulting to v$Version"
         }
 

--- a/src/MetasysRestClient/Connect-MetasysAccount.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.ps1
@@ -207,7 +207,7 @@ function Connect-MetasysAccount {
         }
 
         if ($Version -eq "") {
-            $Version = $env:METASYS_DEFAULT_API_VERSION ?? (Get-MetasysLatestVersion)
+            $Version = (Get-MetasysDefaultApiVersion) ?? (Get-MetasysLatestVersion)
             Write-Information "No version specified. Defaulting to v$Version"
         }
 

--- a/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
@@ -51,7 +51,7 @@ BeforeAll {
 
     . ./MockConsole.ps1
 
-    Set-Variable -Name LatestVersion -Value 4 -Option Constant
+    Set-Variable -Name LatestVersion -Value (Get-MetasysLatestVersion) -Option Constant
 
     function CreateLoginResponse {
         param(

--- a/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.Tests.ps1
@@ -109,6 +109,8 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
 
                 }
 
+                Mock Get-MetasysDefaultApiVersion -ModuleName MetasysRestClient
+
                 Invoke-MetasysMethod
             }
 
@@ -172,6 +174,10 @@ Describe "Invoke-MetasysMethod" -Tag Unit {
                 Mock Get-SavedMetasysPassword -ModuleName MetasysRestClient {
                     ConvertTo-SecureString -String "ThePassword" -AsPlainText
                 }
+                Mock Get-MetasysSkipSecureCheckNotSecure -ModuleName MetasysRestClient {
+                    $null
+                }
+
                 Invoke-MetasysMethod /objects
             }
 

--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -195,7 +195,7 @@ function Invoke-MetasysMethod {
 
         If ($Version -eq "") {
             # Use the version from last cma call, else the default api version (if set), else latest version
-            $Version = $env:METASYS_VERSION ?? $env:METASYS_DEFAULT_API_VERSION ?? $LatestVersion
+            $Version = $env:METASYS_VERSION ?? $env:METASYS_DEFAULT_API_VERSION ?? (Get-MetasysLatestVersion)
             Write-Information "No version specified. Defaulting to v$Version"
         }
 

--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -180,7 +180,7 @@ function Invoke-MetasysMethod {
 
 
         if (!$SkipCertificateCheck.IsPresent) {
-            $SkipCertificateCheck = [MetasysEnvVars]::getDefaultSkipCheck()
+            $SkipCertificateCheck = Get-MetasysSkipSecureCheckNotSecure
         }
 
         $uri = [Uri]::new($path, [UriKind]::RelativeOrAbsolute)
@@ -195,7 +195,7 @@ function Invoke-MetasysMethod {
 
         If ($Version -eq "") {
             # Use the version from last cma call, else the default api version (if set), else latest version
-            $Version = $env:METASYS_VERSION ?? $env:METASYS_DEFAULT_API_VERSION ?? (Get-MetasysLatestVersion)
+            $Version = $env:METASYS_VERSION ?? (Get-MetasysDefaultApiVersion) ?? (Get-MetasysLatestVersion)
             Write-Information "No version specified. Defaulting to v$Version"
         }
 

--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -211,6 +211,9 @@ function Invoke-MetasysMethod {
                 if ([DateTimeOffset]::UtcNow -gt $expiration) {
                     # Token is expired, attempt to connect with previously used site host and user name
                     try {
+                        Write-Information "Session has expired. Trying to reconnect with this command:"
+                        Write-Information "Connect-MetasysAccount -SiteHost $([MetasysEnvVars]::getSiteHost()) -UserName $([MetasysEnvVars]::getUserName()) -Version $($Version) `
+-                         -SkipCertificateCheck:$($SkipCertificateCheck)"
                         Connect-MetasysAccount -SiteHost ([MetasysEnvVars]::getSiteHost()) -UserName ([MetasysEnvVars]::getUserName()) -Version $Version `
                             -SkipCertificateCheck:$SkipCertificateCheck
                     }

--- a/src/MetasysRestClient/MetasysRestClient.psd1
+++ b/src/MetasysRestClient/MetasysRestClient.psd1
@@ -8,7 +8,7 @@
     # Script module or binary module file associated with this manifest.
     RootModule           = 'Invoke-MetasysMethod.psm1'
 
-    NestedModules        = @("metasys-env-vars.ps1", "PasswordManagement.ps1", "build-uri.ps1", "build-request.ps1", "Connect-MetasysAccount.ps1", "Read-ConfigFile.ps1")
+    NestedModules        = @("metasys-env-vars.ps1", "PasswordManagement.ps1", "build-uri.ps1", "build-request.ps1", "Connect-MetasysAccount.ps1", "Read-ConfigFile.ps1", "constants.ps1")
 
     # Version number of this module.
     ModuleVersion        = '2.1.3'
@@ -70,7 +70,7 @@
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport    = 'Invoke-MetasysMethod', 'Show-LastMetasysHeaders', 'Show-LastMetasysAccessToken', 'Show-LastMetasysResponseBody', 'Show-LastMetasysFullResponse',
     'Get-LastMetasysResponseBodyAsObject', 'Show-LastMetasysStatus', "Get-SavedMetasysUsers", "Get-SavedMetasysPassword", "Remove-SavedMetasysPassword", "Set-SavedMetasysPassword",
-    'Get-LastMetasysHeadersAsObject', 'Clear-MetasysEnvVariables', 'Connect-MetasysAccount'
+    'Get-LastMetasysHeadersAsObject', 'Clear-MetasysEnvVariables', 'Connect-MetasysAccount', 'Get-MetasysLatestVersion'
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport      = @()

--- a/src/MetasysRestClient/MetasysRestClient.psd1
+++ b/src/MetasysRestClient/MetasysRestClient.psd1
@@ -8,7 +8,7 @@
     # Script module or binary module file associated with this manifest.
     RootModule           = 'Invoke-MetasysMethod.psm1'
 
-    NestedModules        = @("metasys-env-vars.ps1", "PasswordManagement.ps1", "build-uri.ps1", "build-request.ps1", "Connect-MetasysAccount.ps1", "Read-ConfigFile.ps1", "constants.ps1")
+    NestedModules        = @("metasys-env-vars.ps1", "PasswordManagement.ps1", "build-uri.ps1", "build-request.ps1", "Connect-MetasysAccount.ps1", "Read-ConfigFile.ps1", "constants.ps1", "preferences.ps1")
 
     # Version number of this module.
     ModuleVersion        = '2.1.3'
@@ -70,7 +70,9 @@
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport    = 'Invoke-MetasysMethod', 'Show-LastMetasysHeaders', 'Show-LastMetasysAccessToken', 'Show-LastMetasysResponseBody', 'Show-LastMetasysFullResponse',
     'Get-LastMetasysResponseBodyAsObject', 'Show-LastMetasysStatus', "Get-SavedMetasysUsers", "Get-SavedMetasysPassword", "Remove-SavedMetasysPassword", "Set-SavedMetasysPassword",
-    'Get-LastMetasysHeadersAsObject', 'Clear-MetasysEnvVariables', 'Connect-MetasysAccount', 'Get-MetasysLatestVersion'
+    'Get-LastMetasysHeadersAsObject', 'Clear-MetasysEnvVariables', 'Connect-MetasysAccount', 'Get-MetasysLatestVersion', 'Set-MetasysDefaultApiVersion', 'Get-MetasysDefaultApiVersion',
+    'Set-MetasysSkipSecureCheckNotSecure', 'Reset-MetasysSkipSecureCheckNotSecure', 'Get-MetasysSkipSecureCheckNotSecure'
+
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport      = @()

--- a/src/MetasysRestClient/constants.ps1
+++ b/src/MetasysRestClient/constants.ps1
@@ -1,0 +1,5 @@
+function Get-MetasysLatestVersion {
+    "5"
+}
+
+Export-ModuleMember -Function "Get-MetasysLatestVersion"

--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -62,14 +62,15 @@ class MetasysEnvVars {
 
     static [void] clear() {
         $env:METASYS_ACCESS_TOKEN = $null
-        $env:METASYS_HOST = $null
-        $env:METASYS_VERSION = $null
-        $env:METASYS_LAST_RESPONSE = $null
         $env:METASYS_EXPIRES = $null
+        $env:METASYS_HOST = $null
+        $env:METASYS_LAST_HEADERS = $null
+        $env:METASYS_LAST_RESPONSE = $null
         $env:METASYS_LAST_STATUS_CODE = $null
         $env:METASYS_LAST_STATUS_DESCRIPTION = $null
-        $env:METASYS_LAST_HEADERS = $null
+        $env:METASYS_SKIP_CERTIFICATE_CHECK = $null
         $env:METASYS_USER_NAME = $null
+        $env:METASYS_VERSION = $null
     }
 
     static [void] setHeaders([Hashtable]$headers) {

--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -90,16 +90,6 @@ class MetasysEnvVars {
         return "$($env:METASYS_LAST_STATUS_CODE) ($($env:METASYS_LAST_STATUS_DESCRIPTION))"
     }
 
-    static [Boolean] getDefaultSkipCheck() {
-        # Need to convert string value into Boolean
-        if ($env:METASYS_SKIP_CHECK_NOT_SECURE -eq "True") {
-            return $true
-        }
-        else {
-            return $false
-        }
-    }
-
     static [Boolean] getSkipCertificateCheck() {
         # Need to convert string value into Boolean
         if ($env:METASYS_SKIP_CERTIFICATE_CHECK -eq "True") {
@@ -123,3 +113,4 @@ class MetasysEnvVars {
     }
 
 }
+

--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -104,7 +104,8 @@ class MetasysEnvVars {
         # Need to convert string value into Boolean
         if ($env:METASYS_SKIP_CERTIFICATE_CHECK -eq "True") {
             return $true
-        } else {
+        }
+        else {
             return $false
         }
     }

--- a/src/MetasysRestClient/metasys-env-vars.ps1
+++ b/src/MetasysRestClient/metasys-env-vars.ps1
@@ -90,7 +90,13 @@ class MetasysEnvVars {
     }
 
     static [Boolean] getDefaultSkipCheck() {
-        return $env:METASYS_SKIP_CHECK_NOT_SECURE
+        # Need to convert string value into Boolean
+        if ($env:METASYS_SKIP_CHECK_NOT_SECURE -eq "True") {
+            return $true
+        }
+        else {
+            return $false
+        }
     }
 
     static [Boolean] getSkipCertificateCheck() {

--- a/src/MetasysRestClient/preferences.ps1
+++ b/src/MetasysRestClient/preferences.ps1
@@ -1,0 +1,37 @@
+
+<#
+Preferences are writable by our users, but we should treat
+them as read-only.
+#>
+
+function Set-MetasysDefaultApiVersion {
+    param (
+        [string]$Version
+    )
+    $env:METASYS_DEFAULT_API_VERSION = $Version
+}
+
+function Get-MetasysDefaultApiVersion {
+    $env:METASYS_DEFAULT_API_VERSION
+}
+
+function Set-MetasysSkipSecureCheckNotSecure {
+    $env:METASYS_SKIP_CHECK_NOT_SECURE = $true
+}
+
+function Reset-MetasysSkipSecureCheckNotSecure {
+    $env:METASYS_SKIP_CHECK_NOT_SECURE = $null
+}
+
+function Get-MetasysSkipSecureCheckNotSecure {
+
+    if ($env:METASYS_SKIP_CHECK_NOT_SECURE -eq 'True') {
+        $true
+    }
+    else {
+        $false
+    }
+}
+
+Export-ModuleMember -Function 'Set-MetasysDefaultApiVersion', 'Get-MetasysDefaultApiVersion',
+'Set-MetasysSkipSecureCheckNotSecure', 'Reset-MetasysSkipSecureCheckNotSecure', 'Get-MetasysSkipSecureCheckNotSecure'


### PR DESCRIPTION
Includes the following changes:

- correct bug in getDefaultSkipCheck that didn't convert string to boolean correctly
- correct bug where clear wasn't clearing all env variables
- feat: add Write-Information on reconnect
- bug: $LatestVersion differed between source and test
- bug: "preferences" were not adequately accounted for in tests.