### PR TITLE
bug: use skip-check from config file if set

### DIFF
--- a/src/MetasysRestClient/Connect-MetasysAccount.ps1
+++ b/src/MetasysRestClient/Connect-MetasysAccount.ps1
@@ -178,7 +178,7 @@ function Connect-MetasysAccount {
             }
             if ($HostEntryProperties['skip-certificate-check']) {
                 $SkipCertificateCheck = $true
-                Write-Information "Alias s'$($HostEntry.alias)' is configured to skip certificate checking."
+                Write-Information "Alias '$($HostEntry.alias)' is configured to skip certificate checking."
             }
         }
 
@@ -212,10 +212,13 @@ function Connect-MetasysAccount {
         }
 
         # Need to use $PSBoundParameters to check to see if a switch is present. (.IsPresent just casts the value to boolean, so if it was set to `false` IsPresent returns `$true`)
-        if(!$PSBoundParameters.ContainsKey('SkipCertificateCheck')) {
+        if (!$PSBoundParameters.ContainsKey('SkipCertificateCheck')) {
             # switch parameter was not passed by the caller
-            # default to the user preference
-            $SkipCertificateCheck = Get-MetasysSkipSecureCheckNotSecure
+            # however, it may have been set by a host entry in the .metasysrestclient config file
+            # So only use the default if the switch in the config file wasn't explicitly set
+            if (!$SkipCertificateCheck) {
+                $SkipCertificateCheck = Get-MetasysSkipSecureCheckNotSecure
+            }
         }
 
 


### PR DESCRIPTION
A recent change to honor the default user preference for skip certificate check, broke the code that tries to use the host entry information associated with an alias.

What was happening is that the code was checking to see if SkipCertificateCheck was specified on the cli and if not then returning the value from $env:METASYS_SKIP_CHECK_NOT_SECURE which if not set will return $false.

Now the code checks to see if the switch is not already set before falling back to the user preference.

cc: @hicksjacobp 