### PR TITLE
docs: explain how secret management prompts for password

### DIFF
--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -54,6 +54,12 @@ following command to configure SecretStore. _Use at your own risk._
 PS > Set-SecretStoreConfiguration -Authentication None -Interaction None
 ```
 
+> **Note** \
+> The system will still prompt you for a password. Go ahead and enter a password,
+> then enter it again for confirmation. Next the system will ask you to enter the
+> password a third time to confirm that you don't want a password. (Yes, I know this
+> is odd.)
+
 ### Authentication with Password
 
 If your vault will store sensitive passwords you'll want to set a password for


### PR DESCRIPTION
So the system when you run

Set-SecretStoreConfiguration -Authentication None -Interaction None

seems to prompt you for a password, then to confirm the password. Then it asks for the password to confirm that you don't want a password.