### PR TITLE
bug: always convert form json as hashtable

### DIFF
--- a/src/MetasysRestClient/Invoke-MetasysMethod.psm1
+++ b/src/MetasysRestClient/Invoke-MetasysMethod.psm1
@@ -354,18 +354,16 @@ function ConvertFrom-JsonSafely {
         [String]$json
     )
 
+    # Always use -AsHashtable since we have some enum sets that
+    # have keys that vary only in casing in the same enum set.
     try {
-        ConvertFrom-Json -InputObject $json
+        ConvertFrom-Json -AsHashtable -InputObject $json
     }
     catch {
-        try {
-            ConvertFrom-Json -AsHashtable -InputObject $json
-        }
-        catch {
-            # apparently this wasn't JSON so leave it as is
-            $json
-        }
+        # apparently this wasn't JSON so leave it as is
+        $json
     }
+
 }
 
 function Show-LastMetasysResponseBody {


### PR DESCRIPTION
This is because some enum sets returned by /enumerations have keys that differ only in casing.

As of powershell 7.3 this also preserves order by using an OrderedHashtable.